### PR TITLE
feat(auth): use central service token exchange

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <ServiceDefaultsVersion Condition="'$(ServiceDefaultsVersion)' == ''">1.0.89-alpha</ServiceDefaultsVersion>
     <SharedLibraryVersion Condition="'$(SharedLibraryVersion)' == ''">1.0.*-alpha*</SharedLibraryVersion>
   </PropertyGroup>
 

--- a/Maliev.CurrencyService.Api/Dockerfile
+++ b/Maliev.CurrencyService.Api/Dockerfile
@@ -12,6 +12,7 @@ EXPOSE 8081
 FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
+COPY ["Directory.Build.props", "."]
 COPY ["Maliev.CurrencyService.Api/Maliev.CurrencyService.Api.csproj", "Maliev.CurrencyService.Api/"]
 COPY ["Maliev.CurrencyService.Application/Maliev.CurrencyService.Application.csproj", "Maliev.CurrencyService.Application/"]
 COPY ["Maliev.CurrencyService.Domain/Maliev.CurrencyService.Domain.csproj", "Maliev.CurrencyService.Domain/"]
@@ -19,17 +20,18 @@ COPY ["Maliev.CurrencyService.Infrastructure/Maliev.CurrencyService.Infrastructu
 COPY ["nuget.config", "."]
 RUN --mount=type=secret,id=nuget_username \
   --mount=type=secret,id=nuget_password \
+  GITHUB_ACTIONS=true \
   NUGET_USERNAME=$(cat /run/secrets/nuget_username) \
   NUGET_PASSWORD=$(cat /run/secrets/nuget_password) \
   dotnet restore "./Maliev.CurrencyService.Api/Maliev.CurrencyService.Api.csproj"
 COPY . .
 WORKDIR "/src/Maliev.CurrencyService.Api"
-RUN dotnet build "./Maliev.CurrencyService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
+RUN GITHUB_ACTIONS=true dotnet build "./Maliev.CurrencyService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/build
 
 # This stage is used to publish the service project to be copied to the final stage
 FROM build AS publish
 ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "./Maliev.CurrencyService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
+RUN GITHUB_ACTIONS=true dotnet publish "./Maliev.CurrencyService.Api.csproj" -c $BUILD_CONFIGURATION -o /app/publish /p:UseAppHost=false
 
 # This stage is used in production or when running from VS in regular mode (Default when not using the Debug configuration)
 FROM base AS final

--- a/Maliev.CurrencyService.Api/Maliev.CurrencyService.Api.csproj
+++ b/Maliev.CurrencyService.Api/Maliev.CurrencyService.Api.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
 

--- a/Maliev.CurrencyService.Api/Program.cs
+++ b/Maliev.CurrencyService.Api/Program.cs
@@ -91,7 +91,8 @@ try
     builder.Services.AddHostedService<SnapshotProcessingService>();
 
     // IAM Registration
-    builder.AddIAMServiceClient("currency");
+    builder.AddAuthServiceTokenExchange("CurrencyService");
+    builder.AddAuthServiceIAMClient();
     builder.Services.AddIAMRegistration<CurrencyIAMRegistrationService>("currency");
 
     builder.Services.AddControllers();

--- a/Maliev.CurrencyService.Application/Maliev.CurrencyService.Application.csproj
+++ b/Maliev.CurrencyService.Application/Maliev.CurrencyService.Application.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.CurrencyService.Infrastructure/Maliev.CurrencyService.Infrastructure.csproj
+++ b/Maliev.CurrencyService.Infrastructure/Maliev.CurrencyService.Infrastructure.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj
+++ b/Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
-    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(SharedLibraryVersion)" />
+    <PackageReference Include="Maliev.Aspire.ServiceDefaults" Version="$(ServiceDefaultsVersion)" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Maliev.CurrencyService.Tests/Security/AuthorizationFailClosedTests.cs
+++ b/Maliev.CurrencyService.Tests/Security/AuthorizationFailClosedTests.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using Maliev.Aspire.ServiceDefaults.IAM;
+using Maliev.CurrencyService.Api.Services;
+using Maliev.CurrencyService.Infrastructure.Persistence;
+using Maliev.CurrencyService.Tests.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Maliev.CurrencyService.Tests.Security;
+
+/// <summary>
+/// Verifies authorization behavior when the IAM dependency is unavailable.
+/// </summary>
+public sealed class AuthorizationFailClosedTests
+{
+    /// <summary>
+    /// An authenticated caller without a matching token permission must be denied when IAM throws.
+    /// </summary>
+    [Fact]
+    public async Task PermissionProtectedEndpoint_WhenIamThrows_DeniesAccess()
+    {
+        await using var factory = new ThrowingIamCurrencyServiceFactory();
+        await factory.InitializeAsync();
+        using var client = factory.CreateAuthenticatedClient(
+            userId: "iam-outage-user",
+            roles: [],
+            permissions: []);
+
+        using var response = await client.GetAsync(
+            "/currency/v1/currencies?page=1&pageSize=1",
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        factory.IamClient.Verify(
+            client => client.CheckPermissionAsync(
+                "iam-outage-user",
+                CurrencyPermissions.CurrenciesRead,
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    private sealed class ThrowingIamCurrencyServiceFactory
+        : BaseIntegrationTestFactory<Program, CurrencyDbContext>
+    {
+        public Mock<IIamServiceClient> IamClient { get; } = new();
+
+        protected override void ConfigureAdditionalServices(IServiceCollection services)
+        {
+            IamClient
+                .Setup(client => client.CheckPermissionAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string?>(),
+                    It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("IAM unavailable"));
+            services.AddScoped<IIamServiceClient>(_ => IamClient.Object);
+        }
+    }
+}

--- a/Maliev.CurrencyService.Tests/Testing/BaseIntegrationTestFactory.cs
+++ b/Maliev.CurrencyService.Tests/Testing/BaseIntegrationTestFactory.cs
@@ -189,7 +189,7 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
                 ["RateLimiting:Auth:PermitLimit"] = "10000",
                 ["RateLimiting:Public:PermitLimit"] = "10000",
                 ["IAM:RegistrationDelaySeconds"] = "0",
-                ["Features:FailOpenOnIAMError"] = "true"
+                ["Features:FailOpenOnIAMError"] = "false"
             });
         });
 

--- a/Maliev.CurrencyService.Tests/Testing/BaseIntegrationTestFactory.cs
+++ b/Maliev.CurrencyService.Tests/Testing/BaseIntegrationTestFactory.cs
@@ -64,7 +64,7 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
         {
             if (!_containersStarted)
             {
-                _postgresContainer = 
+                _postgresContainer =
 #pragma warning disable CS0618
         new PostgreSqlBuilder().WithImage("postgres:18-alpine")
                     .Build();
@@ -175,6 +175,14 @@ public class BaseIntegrationTestFactory<TProgram, TDbContext> : WebApplicationFa
                 ["ConnectionStrings:rabbitmq"] = _rabbitmqContainer!.GetConnectionString(),
                 ["CORS:AllowedOrigins:0"] = "http://localhost:3000",
                 ["CORS_ALLOWED_ORIGINS"] = "http://localhost:3000",
+                ["ServiceAuthentication:ClientId"] = "service-currency-service",
+                ["ServiceAuthentication:ClientSecret"] = "currency-test-secret-with-at-least-32-bytes",
+                ["Services:AuthService:BaseUrl"] = "https://auth.test",
+                ["Services:IAMService:BaseUrl"] = "https://iam.test",
+                ["Jwt:PublicKey"] = Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes(_testRsa.ExportSubjectPublicKeyInfoPem())),
+                ["Jwt:Issuer"] = "https://test-issuer.maliev.com",
+                ["Jwt:Audience"] = "https://test-audience.maliev.com",
                 ["RateLimiting:PermitLimit"] = "10000",
                 ["RateLimiting:WindowMinutes"] = "1",
                 ["RateLimiting:Admin:PermitLimit"] = "10000",

--- a/Maliev.CurrencyService.Tests/Unit/ServiceAuthenticationWiringTests.cs
+++ b/Maliev.CurrencyService.Tests/Unit/ServiceAuthenticationWiringTests.cs
@@ -1,0 +1,373 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text;
+using Asp.Versioning;
+using Maliev.Aspire.ServiceDefaults.Authorization;
+using Maliev.Aspire.ServiceDefaults.IAM;
+using Maliev.CurrencyService.Api.Controllers;
+using Maliev.CurrencyService.Api.Services;
+using Maliev.CurrencyService.Infrastructure.Services.External;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Http;
+using Microsoft.Extensions.Options;
+
+namespace Maliev.CurrencyService.Tests.Unit;
+
+/// <summary>
+/// Tests CurrencyService's outbound workload authentication boundary.
+/// </summary>
+public sealed class ServiceAuthenticationWiringTests
+{
+    private const string ExpectedToken = "centrally-issued-currency-token";
+
+    /// <summary>
+    /// CurrencyService startup should opt into AuthService exchange and the central IAM client only.
+    /// </summary>
+    [Fact]
+    public void Program_RegistersCurrencyExchangeWithoutLegacySigner()
+    {
+        var source = ReadRepositoryFile("Maliev.CurrencyService.Api", "Program.cs");
+
+        Assert.Contains("builder.AddAuthServiceTokenExchange(\"CurrencyService\");", source, StringComparison.Ordinal);
+        Assert.Contains("builder.AddAuthServiceIAMClient();", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("AddIAMServiceClient", source, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The process identity should be exact and no local-signing services should resolve.
+    /// </summary>
+    [Fact]
+    public void AuthServiceIamClient_RegistersExactIdentityWithoutLegacySigningServices()
+    {
+        var builder = CreateConfiguredBuilder();
+
+        builder.AddAuthServiceTokenExchange("CurrencyService");
+        builder.AddAuthServiceIAMClient();
+
+        using var provider = builder.Services.BuildServiceProvider();
+        var identity = provider.GetRequiredService<ServiceProcessIdentity>();
+
+        Assert.Equal("CurrencyService", identity.ServiceName);
+        Assert.Single(provider.GetServices<IIamServiceClient>());
+        Assert.Null(provider.GetService<IServiceAccountTokenProvider>());
+        Assert.Null(provider.GetService<ServiceAccountAuthenticationHandler>());
+    }
+
+    /// <summary>
+    /// IAM permission checks should use the AuthService bearer on the exact POST route.
+    /// </summary>
+    [Fact]
+    public async Task IamPermissionCheck_UsesAuthServiceExchangedBearerTokenOnExactPostRoute()
+    {
+        var builder = CreateConfiguredBuilder();
+        var filter = new TrackingPrimaryHandlerFilter();
+        builder.Services.AddSingleton<IHttpMessageHandlerBuilderFilter>(filter);
+
+        builder.AddAuthServiceTokenExchange("CurrencyService");
+        builder.Services.AddSingleton<IAuthServiceTokenProvider>(new StubTokenProvider());
+        builder.AddAuthServiceIAMClient();
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        await using var scope = provider.CreateAsyncScope();
+        var iamClient = scope.ServiceProvider.GetRequiredService<IIamServiceClient>();
+
+        var allowed = await iamClient.CheckPermissionAsync(
+            $"currency-test-{Guid.NewGuid():N}",
+            CurrencyPermissions.CurrenciesRead,
+            cancellationToken: CancellationToken.None);
+
+        var capture = filter.GetCapture("IAMService");
+        Assert.True(allowed);
+        Assert.Equal(new AuthenticationHeaderValue("Bearer", ExpectedToken), capture.Authorization);
+        Assert.Equal(HttpMethod.Post, capture.Method);
+        Assert.Equal(new Uri("https://iam.test/iam/v1/auth/check-permission"), capture.RequestUri);
+    }
+
+    /// <summary>
+    /// Missing or malformed workload credentials should fail options validation during host startup.
+    /// </summary>
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData("service-currency-service", "short")]
+    public async Task AuthServiceExchange_InvalidCredentials_FailsClosedAtHostStartup(
+        string? clientId,
+        string? clientSecret)
+    {
+        var builder = CreateConfiguredBuilder(clientId, clientSecret);
+        builder.AddAuthServiceTokenExchange("CurrencyService");
+
+        using var host = builder.Build();
+
+        await Assert.ThrowsAsync<OptionsValidationException>(() => host.StartAsync());
+    }
+
+    /// <summary>
+    /// CI should consume the exact published ServiceDefaults version containing central exchange support.
+    /// </summary>
+    [Fact]
+    public void ServiceDefaultsDependency_PinsPublishedCentralExchangeVersion()
+    {
+        var source = ReadRepositoryFile("Directory.Build.props");
+
+        Assert.Contains(
+            "<ServiceDefaultsVersion Condition=\"'$(ServiceDefaultsVersion)' == ''\">1.0.89-alpha</ServiceDefaultsVersion>",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "<ServiceDefaultsVersion Condition=\"'$(ServiceDefaultsVersion)' == ''\">1.0.*",
+            source,
+            StringComparison.Ordinal);
+
+        foreach (var project in new[]
+                 {
+                     "Maliev.CurrencyService.Api/Maliev.CurrencyService.Api.csproj",
+                     "Maliev.CurrencyService.Application/Maliev.CurrencyService.Application.csproj",
+                     "Maliev.CurrencyService.Infrastructure/Maliev.CurrencyService.Infrastructure.csproj",
+                     "Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj"
+                 })
+        {
+            var projectSource = ReadRepositoryFile(project.Split('/'));
+            Assert.Contains(
+                "<PackageReference Include=\"Maliev.Aspire.ServiceDefaults\" Version=\"$(ServiceDefaultsVersion)\" />",
+                projectSource,
+                StringComparison.Ordinal);
+        }
+    }
+
+    /// <summary>
+    /// The Docker restore layer must include the shared version property before restoring package-mode projects.
+    /// </summary>
+    [Fact]
+    public void Dockerfile_CopiesSharedVersionPropertiesBeforePackageRestore()
+    {
+        var source = ReadRepositoryFile("Maliev.CurrencyService.Api", "Dockerfile");
+        var propertiesCopy = source.IndexOf(
+            "COPY [\"Directory.Build.props\", \".\"]",
+            StringComparison.Ordinal);
+        var restore = source.IndexOf(
+            "dotnet restore \"./Maliev.CurrencyService.Api/Maliev.CurrencyService.Api.csproj\"",
+            StringComparison.Ordinal);
+
+        Assert.True(propertiesCopy >= 0, "Dockerfile must copy Directory.Build.props into the restore layer.");
+        Assert.True(restore > propertiesCopy, "Directory.Build.props must be available before dotnet restore.");
+    }
+
+    /// <summary>
+    /// Currency routes and permission policies are part of the service contract and must remain unchanged.
+    /// </summary>
+    [Fact]
+    public void CurrencyEndpoints_RetainVersionedRoutesAndPermissionPolicies()
+    {
+        AssertControllerRoute<CurrenciesController>("currency/v{version:apiVersion}/currencies");
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.ListCurrencies), null, "GET", CurrencyPermissions.CurrenciesRead);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.GetCurrencyById), "{id:guid}", "GET", CurrencyPermissions.CurrenciesRead);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.GetCurrencyByCountryPath), "~/currency/v{version:apiVersion}/countries/{countryCode}/currency", "GET", CurrencyPermissions.CurrenciesRead);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.GetCurrencyByCountry), "by-country", "GET", CurrencyPermissions.CurrenciesRead);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.GetByCode), "{code}", "GET", CurrencyPermissions.CurrenciesRead);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.GetById), "~/currency/v{version:apiVersion}/admin/currencies/{id:guid}", "GET", CurrencyPermissions.CurrenciesRead);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.CreateAdmin), "~/currency/v{version:apiVersion}/admin/currencies", "POST", CurrencyPermissions.CurrenciesCreate);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.Update), "{code}", "PUT", CurrencyPermissions.CurrenciesUpdate);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.UpdateById), "~/currency/v{version:apiVersion}/admin/currencies/{id:guid}", "PUT", CurrencyPermissions.CurrenciesUpdate);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.DeleteById), "~/currency/v{version:apiVersion}/admin/currencies/{id:guid}", "DELETE", CurrencyPermissions.CurrenciesDelete);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.Delete), "{code}", "DELETE", CurrencyPermissions.CurrenciesDelete);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.Activate), "~/currency/v{version:apiVersion}/admin/currencies/{id:guid}/activate", "POST", CurrencyPermissions.CurrenciesActivate);
+        AssertEndpoint<CurrenciesController>(nameof(CurrenciesController.Deactivate), "~/currency/v{version:apiVersion}/admin/currencies/{id:guid}/deactivate", "POST", CurrencyPermissions.CurrenciesActivate);
+
+        AssertControllerRoute<RatesController>("currency/v{version:apiVersion}/rates");
+        AssertEndpoint<RatesController>(nameof(RatesController.ConvertCurrency), "convert", "POST", CurrencyPermissions.RatesRead);
+        AssertEndpoint<RatesController>(nameof(RatesController.GetExchangeRate), null, "GET", CurrencyPermissions.RatesRead);
+        AssertEndpoint<RatesController>(nameof(RatesController.UpdateRate), null, "PUT", CurrencyPermissions.RatesUpdate);
+        AssertEndpoint<RatesController>(nameof(RatesController.BulkUpdateRates), "bulk-update", "POST", CurrencyPermissions.RatesBulkUpdate);
+        AssertEndpoint<RatesController>(nameof(RatesController.SetRateSource), "set-source", "POST", CurrencyPermissions.RatesSetSource);
+        AssertEndpoint<RatesController>(nameof(RatesController.RefreshRatesFromProvider), "refresh", "POST", CurrencyPermissions.SystemRefreshRates);
+
+        AssertControllerRoute<SnapshotsController>("currency/v{version:apiVersion}/admin/snapshots");
+        AssertEndpoint<SnapshotsController>(nameof(SnapshotsController.ImportBatch), "ingest", "POST", CurrencyPermissions.SnapshotsCreate);
+        AssertEndpoint<SnapshotsController>(nameof(SnapshotsController.PromoteBatch), "{batchId}/promote", "POST", CurrencyPermissions.SnapshotsCreate);
+        AssertEndpoint<SnapshotsController>(nameof(SnapshotsController.CleanupOldSnapshots), "cleanup", "POST", CurrencyPermissions.SnapshotsDelete);
+        AssertEndpoint<SnapshotsController>(nameof(SnapshotsController.GetBatchStatus), "{batchId}/status", "GET", CurrencyPermissions.SnapshotsRead);
+        AssertEndpoint<SnapshotsController>(nameof(SnapshotsController.GetBatchAudit), "{batchId}/audit", "GET", CurrencyPermissions.SnapshotsAudit);
+
+        AssertControllerRoute<SystemController>("currency/v{version:apiVersion}/system");
+        AssertEndpoint<SystemController>(nameof(SystemController.RebuildCache), "rebuild-cache", "POST", CurrencyPermissions.SystemRebuildCache);
+        AssertEndpoint<SystemController>(nameof(SystemController.GetStats), "stats", "GET", CurrencyPermissions.SystemViewStats);
+    }
+
+    /// <summary>
+    /// AuthService exchange must not add its handler or bearer to either public exchange-rate provider.
+    /// </summary>
+    [Fact]
+    public async Task AuthServiceExchange_DoesNotContaminateExchangeRateProviderClients()
+    {
+        var builder = CreateConfiguredBuilder();
+        var filter = new TrackingPrimaryHandlerFilter();
+        var tokenProvider = new CountingTokenProvider();
+        builder.Services.AddSingleton<IHttpMessageHandlerBuilderFilter>(filter);
+        builder.Services.AddHttpClient<FawazahmedProvider>().AddStandardResilienceHandler();
+        builder.Services.AddHttpClient<FrankfurterProvider>().AddStandardResilienceHandler();
+
+        builder.AddAuthServiceTokenExchange("CurrencyService");
+        builder.Services.AddSingleton<IAuthServiceTokenProvider>(tokenProvider);
+        builder.AddAuthServiceIAMClient();
+
+        await using var provider = builder.Services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+        var providerNames = new[]
+        {
+            typeof(FawazahmedProvider).FullName!,
+            typeof(FrankfurterProvider).FullName!
+        };
+
+        foreach (var providerName in providerNames)
+        {
+            var client = factory.CreateClient(providerName);
+            using var response = await client.GetAsync("https://provider.test/probe", CancellationToken.None);
+            var capture = filter.GetCapture(providerName);
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.False(filter.HasAuthServiceHandler(providerName));
+            Assert.Null(capture.Authorization);
+            Assert.Equal(HttpMethod.Get, capture.Method);
+            Assert.Equal(new Uri("https://provider.test/probe"), capture.RequestUri);
+        }
+
+        Assert.Equal(0, tokenProvider.CallCount);
+    }
+
+    private static HostApplicationBuilder CreateConfiguredBuilder(
+        string? clientId = "service-currency-service",
+        string? clientSecret = "currency-test-secret-with-at-least-32-bytes")
+    {
+        var builder = Host.CreateApplicationBuilder(new HostApplicationBuilderSettings
+        {
+            EnvironmentName = "Testing"
+        });
+
+        using var rsa = RSA.Create(2048);
+        builder.Configuration["ServiceAuthentication:ClientId"] = clientId;
+        builder.Configuration["ServiceAuthentication:ClientSecret"] = clientSecret;
+        builder.Configuration["Services:AuthService:BaseUrl"] = "https://auth.test";
+        builder.Configuration["Services:IAMService:BaseUrl"] = "https://iam.test";
+        builder.Configuration["Jwt:PublicKey"] = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(rsa.ExportSubjectPublicKeyInfoPem()));
+        builder.Configuration["Jwt:Issuer"] = "https://api.maliev.com";
+        builder.Configuration["Jwt:Audience"] = "https://api.maliev.com";
+
+        return builder;
+    }
+
+    private static void AssertControllerRoute<TController>(string expectedTemplate)
+    {
+        var controller = typeof(TController);
+        Assert.NotNull(controller.GetCustomAttribute<ApiVersionAttribute>());
+        Assert.Equal(expectedTemplate, controller.GetCustomAttribute<RouteAttribute>()?.Template);
+    }
+
+    private static void AssertEndpoint<TController>(
+        string methodName,
+        string? expectedTemplate,
+        string expectedVerb,
+        string expectedPermission)
+    {
+        var method = typeof(TController).GetMethod(methodName, BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var route = method.GetCustomAttributes<HttpMethodAttribute>().Single();
+        Assert.Equal(expectedTemplate, route.Template);
+        Assert.Contains(expectedVerb, route.HttpMethods);
+        Assert.Equal(expectedPermission, method.GetCustomAttribute<RequirePermissionAttribute>()?.Permission);
+    }
+
+    private static string ReadRepositoryFile(params string[] segments)
+    {
+        var path = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..",
+            "..",
+            "..",
+            "..",
+            Path.Combine(segments)));
+
+        Assert.True(File.Exists(path), $"Could not find source file: {path}");
+        return File.ReadAllText(path);
+    }
+
+    private sealed class StubTokenProvider : IAuthServiceTokenProvider
+    {
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default) =>
+            Task.FromResult(ExpectedToken);
+    }
+
+    private sealed class CountingTokenProvider : IAuthServiceTokenProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken = default)
+        {
+            CallCount++;
+            return Task.FromResult(ExpectedToken);
+        }
+    }
+
+    private sealed class AuthorizationCaptureHandler : HttpMessageHandler
+    {
+        public AuthenticationHeaderValue? Authorization { get; private set; }
+
+        public HttpMethod? Method { get; private set; }
+
+        public Uri? RequestUri { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Authorization = request.Headers.Authorization;
+            Method = request.Method;
+            RequestUri = request.RequestUri;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"allowed\":true}", Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    private sealed class TrackingPrimaryHandlerFilter : IHttpMessageHandlerBuilderFilter
+    {
+        private readonly Dictionary<string, AuthorizationCaptureHandler> _captures = new(StringComparer.Ordinal);
+        private readonly Dictionary<string, bool> _authHandlers = new(StringComparer.Ordinal);
+
+        public AuthorizationCaptureHandler GetCapture(string clientName) => _captures[clientName];
+
+        public bool HasAuthServiceHandler(string clientName) => _authHandlers[clientName];
+
+        public Action<HttpMessageHandlerBuilder> Configure(Action<HttpMessageHandlerBuilder> next) => builder =>
+        {
+            next(builder);
+            var clientName = builder.Name
+                ?? throw new InvalidOperationException("Every HttpClientFactory handler must have a client name.");
+            _authHandlers[clientName] = builder.AdditionalHandlers.Any(
+                handler => handler is AuthServiceTokenExchangeHandler);
+            for (var index = builder.AdditionalHandlers.Count - 1; index >= 0; index--)
+            {
+                if (builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ServiceDiscovery",
+                        StringComparison.Ordinal) == true ||
+                    builder.AdditionalHandlers[index].GetType().FullName?.Contains(
+                        "ResolvingHttpDelegatingHandler",
+                        StringComparison.Ordinal) == true)
+                {
+                    builder.AdditionalHandlers.RemoveAt(index);
+                }
+            }
+
+            var capture = new AuthorizationCaptureHandler();
+            _captures[clientName] = capture;
+            builder.PrimaryHandler = capture;
+        };
+    }
+}


### PR DESCRIPTION
## Outcome
- migrate CurrencyService IAM calls from legacy local signing to AuthService token exchange
- preserve exact CurrencyService process identity and current endpoint permission metadata
- keep public exchange-rate provider clients isolated from MALIEV bearer authentication
- pin the published ServiceDefaults package and make production Docker package-mode builds reproducible

## Validation
- focused authentication wiring tests: 9/9
- unit-name lane: 137/137
- integration-name lane: 13/13
- full Release suite: 1,238 passed, 3 intentional skips, 0 failed
- package-mode Release build: 0 warnings, 0 errors
- normal Release build: 0 warnings, 0 errors
- production Docker build succeeded: sha256:e460bb382a4b23244a5ffb6c46c3658dddd28058222effec34bc7dc1d8b58cb4
- independent review: approved, no actionable findings

## Tracking
- MALIEV-Co-Ltd/maliev-ops#92

No deployment or GitOps application activation is included.