### PR TITLE
chore(test): update stable coverage tooling

### DIFF
--- a/Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj
+++ b/Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />
     <PackageReference Include="Testcontainers.RabbitMq" Version="4.9.0" />


### PR DESCRIPTION
## Outcome
Reconciles the only two applicable current-file updates from CurrencyService's stale conflict-marked Dependabot backlog:
- `coverlet.collector` 6.0.4 -> 10.0.1 (supersedes #47)
- `Microsoft.NET.Test.Sdk` 17.14.1 -> 18.8.1 (supersedes #52)

All other open Dependabot PRs target deleted scaffold projects/packages, request a banned FluentAssertions dependency, or are already satisfied by the promoted .NET 10 implementation.

## Validation
- exact pinned Aspire/Messaging source restore: passed
- Release build: 0 warnings, 0 errors
- full tests: 1,245 passed, 3 skipped, 0 failed
- NuGet vulnerability audit: no vulnerable packages
- `dotnet format --verify-no-changes`: passed
- actionlint: passed
- `git diff --check`: passed
- staged patch gitleaks: no leaks

No deployment or GitOps mutation is included.