### PR TITLE
Promote validated CurrencyService dependency tree to main

### DIFF
--- a/Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj
+++ b/Maliev.CurrencyService.Tests/Maliev.CurrencyService.Tests.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />
     <PackageReference Include="Testcontainers.RabbitMq" Version="4.9.0" />


### PR DESCRIPTION
Promotes the exact tree already validated on develop at `5cc27f5bf4f0c78afbd466b2de2c707004523139`. Includes reviewed stable test-tool updates consolidated from Dependabot PRs #47 and #52. No deployment or GitOps mutation. Develop CI run 29697442209 completed successfully.